### PR TITLE
feat: upgrade to Bevy 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-bevy = { version = "0.14", default-features = false }
+bevy = { version = "0.17", default-features = false }
 clap = { version = "4.5", features = ["derive"] }
 bevy_headless_console_derive = { path = "./bevy_headless_console_derive", version = "0.5.0" }
 shlex = "1.3"

--- a/examples/raw_commands.rs
+++ b/examples/raw_commands.rs
@@ -10,7 +10,7 @@ fn main() {
         .run();
 }
 
-fn raw_commands(mut console_commands: EventReader<ConsoleCommandEntered>) {
+fn raw_commands(mut console_commands: MessageReader<ConsoleCommandEntered>) {
     for ConsoleCommandEntered { command_name, args } in console_commands.read() {
         println!(r#"Entered command "{command_name}" with args {:#?}"#, args);
     }

--- a/examples/write_to_console.rs
+++ b/examples/write_to_console.rs
@@ -12,6 +12,6 @@ fn main() {
         .run();
 }
 
-fn write_to_console(mut console_line: EventWriter<PrintConsoleLine>) {
-    console_line.send(PrintConsoleLine::new("Hello".into()));
+fn write_to_console(mut console_line: MessageWriter<PrintConsoleLine>) {
+    console_line.write(PrintConsoleLine::new("Hello".into()));
 }

--- a/src/basic_terminal.rs
+++ b/src/basic_terminal.rs
@@ -37,14 +37,14 @@ struct StdinLineReceiver(mpsc::Receiver<String>);
 
 fn convert_stdin_to_events(
     receiver: NonSend<StdinLineReceiver>,
-    mut command_raw_entered: EventWriter<ConsoleCommandRawEntered>,
+    mut command_raw_entered: MessageWriter<ConsoleCommandRawEntered>,
 ) {
     for line in receiver.0.try_iter() {
-        command_raw_entered.send(ConsoleCommandRawEntered(line));
+        command_raw_entered.write(ConsoleCommandRawEntered(line));
     }
 }
 
-fn output_console_lines(mut reader: EventReader<PrintConsoleLine>) {
+fn output_console_lines(mut reader: MessageReader<PrintConsoleLine>) {
     let mut handled = false;
     for line in reader.read() {
         println!("{}", line.line);

--- a/src/commands/exit.rs
+++ b/src/commands/exit.rs
@@ -12,10 +12,10 @@ pub(crate) struct ExitCommand;
 
 pub(crate) fn exit_command(
     mut exit: ConsoleCommand<ExitCommand>,
-    mut exit_writer: EventWriter<AppExit>,
+    mut exit_writer: MessageWriter<AppExit>,
 ) {
     if let Some(Ok(_)) = exit.take() {
-        exit_writer.send(AppExit::Success);
+        exit_writer.write(AppExit::Success);
         exit.ok();
     }
 }

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -27,7 +27,6 @@ pub(crate) fn help_command(
             }
         },
         Some(Ok(HelpCommand { command: None })) => {
-            debug!("No command received in help");
             reply!(help, "Available commands:");
             let longest_command_name = config
                 .commands

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,16 +44,16 @@ pub enum ConsoleSet {
 }
 
 /// Run condition which does not run any command systems if no command was entered
-fn have_commands(commands: EventReader<ConsoleCommandEntered>) -> bool {
+fn have_commands(commands: MessageReader<ConsoleCommandEntered>) -> bool {
     !commands.is_empty()
 }
 
 impl Plugin for ConsolePlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<ConsoleConfiguration>()
-            .add_event::<ConsoleCommandRawEntered>()
-            .add_event::<ConsoleCommandEntered>()
-            .add_event::<PrintConsoleLine>()
+            .add_message::<ConsoleCommandRawEntered>()
+            .add_message::<ConsoleCommandEntered>()
+            .add_message::<PrintConsoleLine>()
             .add_console_command::<ExitCommand, _>(exit_command)
             .add_console_command::<HelpCommand, _>(help_command)
             .add_systems(Update, parse_raw_commands.in_set(ConsoleSet::ConsoleInput))


### PR DESCRIPTION
Migrated from Bevy 0.14 to 0.17, applying all breaking changes:

- Event system → Message system (EventWriter/EventReader → MessageWriter/MessageReader, Event derive → Message derive)
- EventWriter::send() → MessageWriter::write()
- App::add_event() → App::add_message()
- SystemParam::init_state signature change (removed system_meta param)
- Added new SystemParam::init_access implementation
- IntoSystemConfigs → IntoScheduleConfigs<ScheduleSystem, M>
- Resource trait moved from bevy::ecs::system to bevy::ecs::resource
- Removed debug!/warn! macros (not available with default-features=false)